### PR TITLE
Fix DALRCF4 snippets

### DIFF
--- a/DALRCF4-upgrade.cf
+++ b/DALRCF4-upgrade.cf
@@ -6,6 +6,7 @@
 timer C06 0
 timer C07 1
 
+dma pin C06 0
 dma pin A10 1
 dma pin A08 2
 dma pin C08 1

--- a/DALRCF4.cf
+++ b/DALRCF4.cf
@@ -6,6 +6,7 @@
 timer C06 0
 timer C07 1
 
+dma pin C06 0
 dma pin A10 1
 dma pin A08 2
 dma pin C08 1

--- a/boards/DALRCF4
+++ b/boards/DALRCF4
@@ -1,6 +1,7 @@
 timer C06 0
 timer C07 1
 
+dma pin C06 0
 dma pin A10 1
 dma pin A08 2
 dma pin C08 1


### PR DESCRIPTION
The necessary ```dma pin C06 0``` line was removed in 5237a2a713a66f58812f3c9a7dc49dc2f9da8257 , this adds it back to both snippets.

Tested and motors 1 and 2 spin up again, fixing #10 and #4