### PR TITLE
Make upgrade snippet not change filters

### DIFF
--- a/REVOLT-upgrade.cf
+++ b/REVOLT-upgrade.cf
@@ -21,7 +21,7 @@ set pid_process_denom = 1
 
 set motor_pwm_protocol=DSHOT300
 
-# basic settings required to enable rpm filtering:
+# enable debugging for noise assessment
 
 set scheduler_optimize_rate=on
 set dshot_burst=off


### PR DESCRIPTION
The upgrade snippet now does not:
- modify user filters
- change d_Min values
- change d_Min boost value
Logging is set to gyro_smoothed since most users will subsequently wnat to make gyro spectrums.